### PR TITLE
 feat: support NetEase Cloud podcast links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 [![npm](https://img.shields.io/npm/v/koishi-plugin-music-voice?style=flat-square)](https://www.npmjs.com/package/koishi-plugin-music-voice)
 
-🎵 **语音点歌** - 搜索网易云音乐的歌曲，交互后发送语音消息，🤩付费的歌曲也可以欸？！
+🎵 **语音点歌** - 搜索网易云音乐的歌曲，交互后发送语音消息，🤩 付费的歌曲也可以欸？！
 
 ## 特点
 
 - **搜索歌曲**：🤩 支持网易云音乐的歌曲搜索。
+- **播客直链**：🔗 识别 `music.163.com/dj?id=...` 网易云播客链接，直接解析节目并发送语音，不进入普通歌曲搜索列表。
+- **多种发送方式**：🎙️ 支持音频、文件等发送模式，具体取决于 Koishi 配置。
 - **友好交互**：📱 简单易用的指令，快速获取你喜欢的音乐。
 
 ## 安装
@@ -44,15 +46,16 @@ music <歌曲名称>
 【一条时间较长的语音消息】
 ```
 
-## API说明
+## API 说明
 
 本插件使用基于 Meting 构建的 Meting-API 来获取音乐直链。
 
-如果需要更换API，可以直接在浏览器搜索 "Meting-API"，
+如果需要更换 API，可以直接在浏览器搜索 "Meting-API"，
 
-找到你可用的服务 将自定义API地址填入配置项即可。
+找到你可用的服务 将自定义 API 地址填入配置项即可。
 
 相关地址：
+
 - https://github.com/metowolf/Meting
 - https://github.com/injahow/meting-api
 - https://api.injahow.cn/meting/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-music-voice",
   "description": "Provide the selected song as a voice",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,48 +1,68 @@
-import { promises as fs } from 'node:fs'
-import { pathToFileURL } from 'node:url'
+import { promises as fs } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-import { Context, h, isNullable, type Session } from 'koishi'
+import { Context, h, isNullable, type Session } from "koishi";
 
-import type { MessageBehavior } from './message-behavior'
-import { downloadSongFile, fetchSongBuffer, resolveSongSource, searchNetEase } from './network'
-import { buildQQMarkdownSongList, sendQQMarkdownSongList, supportsQQMarkdown } from './qq-markdown'
-import { formatSongList, generateSongListImage } from './render'
-import type { PluginLogger, RateLimitScope, RuntimeConfig, SilentMessage, SongData } from './types'
+import type { MessageBehavior } from "./message-behavior";
+import {
+  downloadSongFile,
+  fetchSongBuffer,
+  resolvePodcastSource,
+  resolveSongSource,
+  searchNetEase,
+} from "./network";
+import {
+  buildQQMarkdownSongList,
+  sendQQMarkdownSongList,
+  supportsQQMarkdown,
+} from "./qq-markdown";
+import { formatSongList, generateSongListImage } from "./render";
+import type {
+  PluginLogger,
+  RateLimitScope,
+  RuntimeConfig,
+  SilentMessage,
+  SongData,
+} from "./types";
 
 interface CommandDependencies {
-  logger: PluginLogger
-  messageBehavior: MessageBehavior
+  logger: PluginLogger;
+  messageBehavior: MessageBehavior;
 }
 
 function quote(messageId?: string | null) {
-  return messageId ? h.quote(messageId) : ''
+  return messageId ? h.quote(messageId) : "";
 }
 
 function getLastMessageId(messageIds: string[]) {
-  return messageIds.at(-1) ?? null
+  return messageIds.at(-1) ?? null;
 }
 
 function getRateLimitKey(scope: RateLimitScope | undefined, session: Session) {
   switch (scope) {
-    case 'channel':
-      return `${session.platform}:${session.channelId}`
-    case 'platform':
-      return session.platform
-    case 'user':
+    case "channel":
+      return `${session.platform}:${session.channelId}`;
+    case "platform":
+      return session.platform;
+    case "user":
     default:
-      return `${session.platform}:${session.userId}`
+      return `${session.platform}:${session.userId}`;
   }
 }
 
-async function deleteMessageSafely(session: Session, messageId: string | null, logger: PluginLogger) {
+async function deleteMessageSafely(
+  session: Session,
+  messageId: string | null,
+  logger: PluginLogger
+) {
   if (!messageId) {
-    return
+    return;
   }
 
   try {
-    await session.bot.deleteMessage(session.channelId, messageId)
+    await session.bot.deleteMessage(session.channelId, messageId);
   } catch (error) {
-    logger.debug('撤回消息失败', messageId, error)
+    logger.debug("撤回消息失败", messageId, error);
   }
 }
 
@@ -50,13 +70,13 @@ async function sendNotice(
   session: Session,
   originalMessageId: string | null,
   key: SilentMessage,
-  messageBehavior: MessageBehavior,
+  messageBehavior: MessageBehavior
 ) {
   if (messageBehavior.shouldSilence(key)) {
-    return
+    return;
   }
 
-  await session.send(`${quote(originalMessageId)}${session.text(`.${key}`)}`)
+  await session.send(`${quote(originalMessageId)}${session.text(`.${key}`)}`);
 }
 
 async function sendSongList(
@@ -68,193 +88,283 @@ async function sendSongList(
   songs: SongData[],
   startIndex: number,
   quoteId: string | null,
-  logger: PluginLogger,
+  logger: PluginLogger
 ) {
   if (config.preferQQMarkdown && supportsQQMarkdown(session)) {
     try {
-      const markdown = buildQQMarkdownSongList(songs, keyword, currentPage, startIndex, config)
-      const messageId = await sendQQMarkdownSongList(session, markdown, logger)
-      return { failed: false, messageId, isMarkdown: true }
+      const markdown = buildQQMarkdownSongList(
+        songs,
+        keyword,
+        currentPage,
+        startIndex,
+        config
+      );
+      const messageId = await sendQQMarkdownSongList(session, markdown, logger);
+      return { failed: false, messageId, isMarkdown: true };
     } catch (error) {
-      logger.warn(`QQ 原生 Markdown 歌单发送失败，已回退为${config.listMode === 'image' ? '图片' : '文本'}歌单。`, error)
+      logger.warn(
+        `QQ 原生 Markdown 歌单发送失败，已回退为${
+          config.listMode === "image" ? "图片" : "文本"
+        }歌单。`,
+        error
+      );
     }
   }
 
-  if (config.listMode === 'image') {
-    const listText = formatSongList(songs, 'NetEase Music', startIndex, true)
+  if (config.listMode === "image") {
+    const listText = formatSongList(songs, "NetEase Music", startIndex, true);
     const exitCommandTip = config.menuExitCommandTip
-      ? session.text('.exitCommandTip', [config.exitCommandList.join(', ')])
-      : ''
-    const imageBuffer = await generateSongListImage(ctx, listText, config, logger)
+      ? session.text(".exitCommandTip", [config.exitCommandList.join(", ")])
+      : "";
+    const imageBuffer = await generateSongListImage(
+      ctx,
+      listText,
+      config,
+      logger
+    );
 
     if (!imageBuffer) {
-      return { failed: true, messageId: null as string | null, isMarkdown: false }
+      return {
+        failed: true,
+        messageId: null as string | null,
+        isMarkdown: false,
+      };
     }
 
-    const promptMessage = session.text('.imageListPrompt', [exitCommandTip.replaceAll('<br/>', '\n'), config.waitForTimeout])
+    const promptMessage = session.text(".imageListPrompt", [
+      exitCommandTip.replaceAll("<br/>", "\n"),
+      config.waitForTimeout,
+    ]);
     const messageIds = await session.send([
       quote(quoteId),
-      h.image(imageBuffer, 'image/png'),
+      h.image(imageBuffer, "image/png"),
       h.text(promptMessage),
-    ])
+    ]);
 
-    return { failed: false, messageId: getLastMessageId(messageIds), isMarkdown: false }
+    return {
+      failed: false,
+      messageId: getLastMessageId(messageIds),
+      isMarkdown: false,
+    };
   }
 
-  const listText = formatSongList(songs, 'NetEase Music', startIndex, false)
+  const listText = formatSongList(songs, "NetEase Music", startIndex, false);
   const exitCommandTip = config.menuExitCommandTip
-    ? session.text('.exitCommandTip', [config.exitCommandList.join(', ')])
-    : ''
-  const promptMessage = session.text('.textListPrompt', [listText, exitCommandTip, config.waitForTimeout]).replaceAll('<br/>', '\n')
-  const messageIds = await session.send(`${quote(quoteId)}${promptMessage}`)
+    ? session.text(".exitCommandTip", [config.exitCommandList.join(", ")])
+    : "";
+  const promptMessage = session
+    .text(".textListPrompt", [listText, exitCommandTip, config.waitForTimeout])
+    .replaceAll("<br/>", "\n");
+  const messageIds = await session.send(`${quote(quoteId)}${promptMessage}`);
 
-  return { failed: false, messageId: getLastMessageId(messageIds), isMarkdown: false }
+  return {
+    failed: false,
+    messageId: getLastMessageId(messageIds),
+    isMarkdown: false,
+  };
 }
 
-async function sendSongByMode(ctx: Context, session: Session, src: string, config: RuntimeConfig) {
+async function sendSongByMode(
+  ctx: Context,
+  session: Session,
+  src: string,
+  config: RuntimeConfig
+) {
   switch (config.srcToWhat) {
-    case 'text':
-      await session.send(h.text(src))
-      return
-    case 'audio':
-      await session.send(h.audio(src))
-      return
-    case 'audiobuffer': {
-      const srcBuffer = await fetchSongBuffer(ctx, src)
-      await session.send(h.audio(srcBuffer, 'audio/mpeg'))
-      return
+    case "text":
+      await session.send(h.text(src));
+      return;
+    case "audio":
+      await session.send(h.audio(src));
+      return;
+    case "audiobuffer": {
+      const srcBuffer = await fetchSongBuffer(ctx, src);
+      await session.send(h.audio(srcBuffer, "audio/mpeg"));
+      return;
     }
-    case 'video':
-      await session.send(h.video(src))
-      return
-    case 'file': {
-      const tempFilePath = await downloadSongFile(ctx, src)
+    case "video":
+      await session.send(h.video(src));
+      return;
+    case "file": {
+      const tempFilePath = await downloadSongFile(ctx, src);
 
       try {
-        await session.send(h.file(pathToFileURL(tempFilePath).href))
+        await session.send(h.file(pathToFileURL(tempFilePath).href));
       } finally {
-        await fs.unlink(tempFilePath).catch(() => {})
+        await fs.unlink(tempFilePath).catch(() => {});
       }
-      return
+      return;
     }
   }
 }
 
-export function registerMusicVoiceCommand(ctx: Context, config: RuntimeConfig, deps: CommandDependencies) {
-  const rateLimitMap = new Map<string, number>()
+export function registerMusicVoiceCommand(
+  ctx: Context,
+  config: RuntimeConfig,
+  deps: CommandDependencies
+) {
+  const rateLimitMap = new Map<string, number>();
 
-  ctx.command(`${config.commandName || 'music'} <keyword:text>`)
-    .option('number', '-n <number:number> 歌曲序号')
-    .option('page', '-p <page:number> 页码')
-    .option('encodedKeyword', '-k <keyword:string> 编码关键词')
+  ctx
+    .command(`${config.commandName || "music"} <keyword:text>`)
+    .option("number", "-n <number:number> 歌曲序号")
+    .option("page", "-p <page:number> 页码")
+    .option("encodedKeyword", "-k <keyword:string> 编码关键词")
     .action(async ({ session, options }, keyword) => {
-      if (typeof options.encodedKeyword === 'string') {
-        keyword = Buffer.from(options.encodedKeyword, 'base64url').toString('utf8')
+      if (typeof options.encodedKeyword === "string") {
+        keyword = Buffer.from(options.encodedKeyword, "base64url").toString(
+          "utf8"
+        );
       }
 
       if (!keyword) {
-        return session.text('.nokeyword')
+        return session.text(".nokeyword");
       }
 
       if (config.enableRateLimit) {
-        const now = Date.now()
-        const rateLimitKey = getRateLimitKey(config.rateLimitScope, session)
-        const lastUseTime = rateLimitMap.get(rateLimitKey)
-        const rateLimitInterval = config.rateLimitInterval ?? 60
+        const now = Date.now();
+        const rateLimitKey = getRateLimitKey(config.rateLimitScope, session);
+        const lastUseTime = rateLimitMap.get(rateLimitKey);
+        const rateLimitInterval = config.rateLimitInterval ?? 60;
 
         if (lastUseTime) {
-          const remainingTime = rateLimitInterval - (now - lastUseTime) / 1000
+          const remainingTime = rateLimitInterval - (now - lastUseTime) / 1000;
 
           if (remainingTime > 0) {
-            return session.text('.rateLimitExceeded', [Math.ceil(remainingTime).toString()])
+            return session.text(".rateLimitExceeded", [
+              Math.ceil(remainingTime).toString(),
+            ]);
           }
         }
 
-        rateLimitMap.set(rateLimitKey, now)
+        rateLimitMap.set(rateLimitKey, now);
       }
 
-      deps.logger.debug('收到点歌请求', session.stripped.content)
+      deps.logger.debug("收到点歌请求", session.stripped.content);
 
-      const originalMessageId = session.messageId ?? null
-      let quoteId = session.messageId ?? null
-      let songListMessageId: string | null = null
-      let selected: SongData | undefined
+      const originalMessageId = session.messageId ?? null;
+      let quoteId = session.messageId ?? null;
+      let songListMessageId: string | null = null;
+      let selected: SongData | undefined;
+      let podcastSource: string | null = null;
 
       const cleanupSongList = async () => {
-        if (deps.messageBehavior.shouldRecall('songList')) {
-          await deleteMessageSafely(session, songListMessageId, deps.logger)
-          songListMessageId = null
+        if (deps.messageBehavior.shouldRecall("songList")) {
+          await deleteMessageSafely(session, songListMessageId, deps.logger);
+          songListMessageId = null;
+        }
+      };
+
+      const podcastMatch = keyword.match(
+        /^https?:\/\/(?:music\.)?163\.com\/dj\?[^\s]*\bid=\d+/i
+      );
+      if (podcastMatch) {
+        try {
+          const podcast = await resolvePodcastSource(
+            ctx,
+            config,
+            podcastMatch[0],
+            deps.logger
+          );
+          podcastSource = podcast.source;
+          selected = {
+            id: podcast.songId,
+            name: "网易云播客",
+            artists: "",
+            albumName: "",
+            duration: podcast.duration,
+          };
+        } catch (error) {
+          deps.logger.warn("解析网易云播客失败", error);
+          return session.text(".getSongFailed");
         }
       }
 
-      let neteaseData: SongData[] = []
-      const requestedPage = Number.isInteger(options.page) && options.page > 0
-        ? options.page - 1
-        : 0
+      let neteaseData: SongData[] = [];
+      const requestedPage =
+        Number.isInteger(options.page) && options.page > 0
+          ? options.page - 1
+          : 0;
 
-      if (options.number !== undefined) {
-        const serialNumber = options.number
+      if (options.number !== undefined && !podcastSource) {
+        const serialNumber = options.number;
 
         if (!Number.isInteger(serialNumber) || serialNumber < 1) {
-          if (deps.messageBehavior.shouldSilence('invalidNumber')) {
-            return
+          if (deps.messageBehavior.shouldSilence("invalidNumber")) {
+            return;
           }
 
-          return `${quote(quoteId)}${session.text('.invalidNumber')}`
+          return `${quote(quoteId)}${session.text(".invalidNumber")}`;
         }
 
-        const pageSize = config.searchListCount
-        const pageIndex = Math.floor((serialNumber - 1) / pageSize)
-        const pageOffset = pageIndex * pageSize
+        const pageSize = config.searchListCount;
+        const pageIndex = Math.floor((serialNumber - 1) / pageSize);
+        const pageOffset = pageIndex * pageSize;
 
         try {
-          neteaseData = await searchNetEase(ctx, config, keyword, pageSize, pageOffset, deps.logger)
+          neteaseData = await searchNetEase(
+            ctx,
+            config,
+            keyword,
+            pageSize,
+            pageOffset,
+            deps.logger
+          );
         } catch (error) {
-          deps.logger.warn('获取网易云歌曲列表失败', error)
-          return session.text('.songlisterror')
+          deps.logger.warn("获取网易云歌曲列表失败", error);
+          return session.text(".songlisterror");
         }
 
         if (!neteaseData.length) {
-          return session.text('.invalidKeyword')
+          return session.text(".invalidKeyword");
         }
 
-        const pageStart = pageOffset + 1
-        const pageEnd = pageOffset + neteaseData.length
+        const pageStart = pageOffset + 1;
+        const pageEnd = pageOffset + neteaseData.length;
 
         if (serialNumber < pageStart || serialNumber > pageEnd) {
-          if (deps.messageBehavior.shouldSilence('invalidNumber')) {
-            return
+          if (deps.messageBehavior.shouldSilence("invalidNumber")) {
+            return;
           }
 
-          return `${quote(quoteId)}${session.text('.invalidNumber')}`
+          return `${quote(quoteId)}${session.text(".invalidNumber")}`;
         }
 
-        selected = neteaseData[serialNumber - pageStart]
-      } else {
-        let currentPage = requestedPage
-        const pageSize = config.searchListCount
+        selected = neteaseData[serialNumber - pageStart];
+      } else if (!podcastSource) {
+        let currentPage = requestedPage;
+        const pageSize = config.searchListCount;
 
         while (true) {
           try {
-            neteaseData = await searchNetEase(ctx, config, keyword, pageSize, currentPage * pageSize, deps.logger)
+            neteaseData = await searchNetEase(
+              ctx,
+              config,
+              keyword,
+              pageSize,
+              currentPage * pageSize,
+              deps.logger
+            );
           } catch (error) {
-            deps.logger.warn('获取网易云歌曲列表失败', error)
-            return session.text('.songlisterror')
+            deps.logger.warn("获取网易云歌曲列表失败", error);
+            return session.text(".songlisterror");
           }
 
           if (!neteaseData.length) {
             if (currentPage === 0) {
-              return session.text('.invalidKeyword')
+              return session.text(".invalidKeyword");
             }
 
-            await session.send(`${quote(quoteId)}${session.text('.noMoreSongs')}`)
-            currentPage--
-            continue
+            await session.send(
+              `${quote(quoteId)}${session.text(".noMoreSongs")}`
+            );
+            currentPage--;
+            continue;
           }
 
-          await cleanupSongList()
+          await cleanupSongList();
 
-          const listStartIndex = currentPage * pageSize
+          const listStartIndex = currentPage * pageSize;
           const songListResult = await sendSongList(
             ctx,
             session,
@@ -264,108 +374,146 @@ export function registerMusicVoiceCommand(ctx: Context, config: RuntimeConfig, d
             neteaseData,
             listStartIndex,
             quoteId,
-            deps.logger,
-          )
+            deps.logger
+          );
 
           if (songListResult.failed) {
-            return session.text('.imageGenerationFailed')
+            return session.text(".imageGenerationFailed");
           }
 
-          songListMessageId = songListResult.messageId
-          quoteId = songListMessageId ?? quoteId
+          songListMessageId = songListResult.messageId;
+          quoteId = songListMessageId ?? quoteId;
 
           // Markdown 菜单通过按钮参数继续交互，不进入 prompt。
           if (songListResult.isMarkdown) {
-            return
+            return;
           }
 
-          const input = await session.prompt((promptSession) => {
-            quoteId = promptSession.messageId ?? quoteId
-            return h.select(promptSession.elements, 'text').join('')
-          }, { timeout: config.waitForTimeout * 1000 })
+          const input = await session.prompt(
+            (promptSession) => {
+              quoteId = promptSession.messageId ?? quoteId;
+              return h.select(promptSession.elements, "text").join("");
+            },
+            { timeout: config.waitForTimeout * 1000 }
+          );
 
           if (isNullable(input)) {
-            await cleanupSongList()
-            await sendNotice(session, originalMessageId, 'promptTimeout', deps.messageBehavior)
-            return
+            await cleanupSongList();
+            await sendNotice(
+              session,
+              originalMessageId,
+              "promptTimeout",
+              deps.messageBehavior
+            );
+            return;
           }
 
-          const trimmedInput = input.trim()
+          const trimmedInput = input.trim();
 
           if (config.exitCommandList.includes(trimmedInput)) {
-            await cleanupSongList()
-            await sendNotice(session, originalMessageId, 'exitPrompt', deps.messageBehavior)
-            return
+            await cleanupSongList();
+            await sendNotice(
+              session,
+              originalMessageId,
+              "exitPrompt",
+              deps.messageBehavior
+            );
+            return;
           }
 
           if (trimmedInput === config.nextPageCommand.trim()) {
-            currentPage++
-            continue
+            currentPage++;
+            continue;
           }
 
           if (trimmedInput === config.prevPageCommand.trim()) {
             if (currentPage > 0) {
-              currentPage--
-              continue
+              currentPage--;
+              continue;
             }
 
-            await session.send(`${quote(quoteId)}${session.text('.alreadyOnFirstPage')}`)
-            continue
+            await session.send(
+              `${quote(quoteId)}${session.text(".alreadyOnFirstPage")}`
+            );
+            continue;
           }
 
-          const serialNumber = Number(trimmedInput)
-          const selectStartIndex = currentPage * pageSize + 1
-          const selectEndIndex = currentPage * pageSize + neteaseData.length
+          const serialNumber = Number(trimmedInput);
+          const selectStartIndex = currentPage * pageSize + 1;
+          const selectEndIndex = currentPage * pageSize + neteaseData.length;
 
-          if (!Number.isInteger(serialNumber) || serialNumber < selectStartIndex || serialNumber > selectEndIndex) {
-            await cleanupSongList()
-            await sendNotice(session, originalMessageId, 'invalidNumber', deps.messageBehavior)
-            return
+          if (
+            !Number.isInteger(serialNumber) ||
+            serialNumber < selectStartIndex ||
+            serialNumber > selectEndIndex
+          ) {
+            await cleanupSongList();
+            await sendNotice(
+              session,
+              originalMessageId,
+              "invalidNumber",
+              deps.messageBehavior
+            );
+            return;
           }
 
-          selected = neteaseData[serialNumber - selectStartIndex]
-          break
+          selected = neteaseData[serialNumber - selectStartIndex];
+          break;
         }
       }
 
       if (!selected) {
-        return
+        return;
       }
 
       if (selected.duration > config.maxSongDuration * 60 * 1000) {
-        await cleanupSongList()
-        await sendNotice(session, originalMessageId, 'durationExceeded', deps.messageBehavior)
-        return
+        await cleanupSongList();
+        await sendNotice(
+          session,
+          originalMessageId,
+          "durationExceeded",
+          deps.messageBehavior
+        );
+        return;
       }
 
-      let tipMessageId: string | null = null
+      let tipMessageId: string | null = null;
 
       if (config.generationTip.trim()) {
-        const tipMessageIds = await session.send(`${quote(quoteId)}${h.text(config.generationTip)}`)
-        tipMessageId = getLastMessageId(tipMessageIds)
+        const tipMessageIds = await session.send(
+          `${quote(quoteId)}${h.text(config.generationTip)}`
+        );
+        tipMessageId = getLastMessageId(tipMessageIds);
       }
 
       const cleanupFinishedMessages = async () => {
-        if (deps.messageBehavior.shouldRecall('generationTip')) {
-          await deleteMessageSafely(session, tipMessageId, deps.logger)
+        if (deps.messageBehavior.shouldRecall("generationTip")) {
+          await deleteMessageSafely(session, tipMessageId, deps.logger);
         }
 
-        await cleanupSongList()
-      }
+        await cleanupSongList();
+      };
 
       try {
-        const src = await resolveSongSource(ctx, config, selected.id, deps.logger)
+        const src =
+          podcastSource ??
+          (await resolveSongSource(ctx, config, selected.id, deps.logger));
 
-        deps.logger.debug('选中歌曲', selected)
-        deps.logger.debug('歌曲直链', src)
-        deps.logger.debug('发送类型', config.srcToWhat)
+        deps.logger.debug("选中歌曲", selected);
+        deps.logger.debug("歌曲直链", src);
+        deps.logger.debug("发送类型", config.srcToWhat);
 
-        await sendSongByMode(ctx, session, src, config)
-        await cleanupFinishedMessages()
+        await sendSongByMode(ctx, session, src, config);
+        await cleanupFinishedMessages();
       } catch (error) {
-        await cleanupFinishedMessages()
-        deps.logger.error('获取歌曲详情或发送语音失败', error)
-        await sendNotice(session, originalMessageId, 'getSongFailed', deps.messageBehavior)
+        await cleanupFinishedMessages();
+        deps.logger.error("获取歌曲详情或发送语音失败", error);
+        await sendNotice(
+          session,
+          originalMessageId,
+          "getSongFailed",
+          deps.messageBehavior
+        );
       }
-    })
+    });
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -313,8 +313,8 @@ export async function resolveSongSource(
   logger: PluginLogger,
 ) {
   const targetUrls = config.type === 'apis'
-    ? PRESET_METING_APIS.map((api) => `${api}?type=url&id=${songId}`)
-    : [`${config.text}?type=url&id=${songId}`]
+    ? PRESET_METING_APIS.map((api) => `${api}?server=netease&type=url&id=${songId}`)
+    : [`${config.text}?server=netease&type=url&id=${songId}`]
 
   return await raceRequests(
     ctx,

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,137 +1,164 @@
-import { promises as fs } from 'node:fs'
-import crypto from 'node:crypto'
-import os from 'node:os'
-import path from 'node:path'
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 
-import type { Context } from 'koishi'
+import type { Context } from "koishi";
 
-import { PRESET_METING_APIS } from './config'
-import type { NetEaseSearchResponse, PluginLogger, RuntimeConfig, SearchRequestMode, SongData } from './types'
+import { PRESET_METING_APIS } from "./config";
+import type {
+  NetEaseSearchResponse,
+  PluginLogger,
+  RuntimeConfig,
+  SearchRequestMode,
+  SongData,
+} from "./types";
 
-const SEARCH_TIMEOUT_MS = 5000
-const SOURCE_TIMEOUT_MS = 5000
-const DOWNLOAD_TIMEOUT_MS = 15000
-const PROXY_URL = 'https://web-proxy.apifox.cn/api/v1/request'
-const REQUEST_TIMEOUT_REASON = 'music-voice-request-timeout'
+const SEARCH_TIMEOUT_MS = 5000;
+const SOURCE_TIMEOUT_MS = 5000;
+const DOWNLOAD_TIMEOUT_MS = 15000;
+const PROXY_URL = "https://web-proxy.apifox.cn/api/v1/request";
+const REQUEST_TIMEOUT_REASON = "music-voice-request-timeout";
 
 interface RequestCandidate {
-  label: string
-  run: (signal: AbortSignal) => Promise<string>
+  label: string;
+  run: (signal: AbortSignal) => Promise<string>;
 }
 
 function getErrorMessage(error: unknown) {
   if (error instanceof Error) {
-    return error.message
+    return error.message;
   }
 
-  return String(error)
+  return String(error);
 }
 
 function getHostLabel(targetUrl: string) {
   try {
-    return new URL(targetUrl).host
+    return new URL(targetUrl).host;
   } catch {
-    return targetUrl
+    return targetUrl;
   }
 }
 
-function createTimeout(ctx: Context, controller: AbortController, timeoutMs: number) {
-  return ctx.setTimeout(() => controller.abort(REQUEST_TIMEOUT_REASON), timeoutMs)
+function createTimeout(
+  ctx: Context,
+  controller: AbortController,
+  timeoutMs: number
+) {
+  return ctx.setTimeout(
+    () => controller.abort(REQUEST_TIMEOUT_REASON),
+    timeoutMs
+  );
 }
 
 async function requestText(targetUrl: string, signal: AbortSignal) {
   const response = await fetch(targetUrl, {
-    method: 'GET',
+    method: "GET",
     signal,
-  })
+  });
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    throw new Error(`HTTP ${response.status}`);
   }
 
-  return await response.text()
+  return await response.text();
 }
 
-async function requestTextByProxy(targetUrl: string, signal: AbortSignal, timeoutMs: number) {
+async function requestTextByProxy(
+  targetUrl: string,
+  signal: AbortSignal,
+  timeoutMs: number
+) {
   const response = await fetch(PROXY_URL, {
-    method: 'POST',
+    method: "POST",
     signal,
     headers: {
-      'api-u': targetUrl,
-      'api-o0': `method=GET, timings=true, timeout=${timeoutMs}`,
-      'Content-Type': 'application/json',
+      "api-u": targetUrl,
+      "api-o0": `method=GET, timings=true, timeout=${timeoutMs}`,
+      "Content-Type": "application/json",
     },
-    body: '{}',
-  })
+    body: "{}",
+  });
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    throw new Error(`HTTP ${response.status}`);
   }
 
-  return await response.text()
+  return await response.text();
 }
 
-function buildCandidates(targetUrls: string[], mode: SearchRequestMode, timeoutMs: number): RequestCandidate[] {
+function buildCandidates(
+  targetUrls: string[],
+  mode: SearchRequestMode,
+  timeoutMs: number
+): RequestCandidate[] {
   return targetUrls.flatMap((targetUrl) => {
-    const label = getHostLabel(targetUrl)
-    const candidates: RequestCandidate[] = []
+    const label = getHostLabel(targetUrl);
+    const candidates: RequestCandidate[] = [];
 
-    if (mode === 'parallel' || mode === 'direct') {
+    if (mode === "parallel" || mode === "direct") {
       candidates.push({
         label: `${label} 直连`,
         run: (signal) => requestText(targetUrl, signal),
-      })
+      });
     }
 
-    if (mode === 'parallel' || mode === 'proxy') {
+    if (mode === "parallel" || mode === "proxy") {
       candidates.push({
         label: `${label} 代理`,
         run: (signal) => requestTextByProxy(targetUrl, signal, timeoutMs),
-      })
+      });
     }
 
-    return candidates
-  })
+    return candidates;
+  });
 }
 
-function buildSearchCandidates(targetUrls: string[], mode: SearchRequestMode, timeoutMs: number) {
-  return buildCandidates(targetUrls, mode, timeoutMs)
+function buildSearchCandidates(
+  targetUrls: string[],
+  mode: SearchRequestMode,
+  timeoutMs: number
+) {
+  return buildCandidates(targetUrls, mode, timeoutMs);
 }
 
 function isMediaContentType(contentType: string | null) {
   if (!contentType) {
-    return false
+    return false;
   }
 
-  const normalized = contentType.toLowerCase()
-  return normalized.startsWith('audio/')
-    || normalized.startsWith('video/')
-    || normalized.includes('application/octet-stream')
+  const normalized = contentType.toLowerCase();
+  return (
+    normalized.startsWith("audio/") ||
+    normalized.startsWith("video/") ||
+    normalized.includes("application/octet-stream")
+  );
 }
 
 async function requestSource(targetUrl: string, signal: AbortSignal) {
   const response = await fetch(targetUrl, {
-    method: 'GET',
+    method: "GET",
     signal,
-  })
+  });
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`)
+    throw new Error(`HTTP ${response.status}`);
   }
 
-  if (isMediaContentType(response.headers.get('content-type'))) {
-    await response.body?.cancel()
-    return response.url || targetUrl
+  if (isMediaContentType(response.headers.get("content-type"))) {
+    await response.body?.cancel();
+    return response.url || targetUrl;
   }
 
-  return await response.text()
+  return await response.text();
 }
 
 function buildDirectCandidates(targetUrls: string[]): RequestCandidate[] {
   return targetUrls.map((targetUrl) => ({
     label: `${getHostLabel(targetUrl)} 直连`,
     run: (signal) => requestSource(targetUrl, signal),
-  }))
+  }));
 }
 
 async function raceRequests<T>(
@@ -140,140 +167,147 @@ async function raceRequests<T>(
   timeoutMs: number,
   parser: (content: string) => T | null,
   description: string,
-  logger: PluginLogger,
+  logger: PluginLogger
 ) {
   if (!candidates.length) {
-    throw new Error(`${description} 没有可用请求。`)
+    throw new Error(`${description} 没有可用请求。`);
   }
 
-  const controllers = candidates.map(() => new AbortController())
+  const controllers = candidates.map(() => new AbortController());
   const tasks = candidates.map(async (candidate, index) => {
-    const controller = controllers[index]
-    const disposeTimeout = createTimeout(ctx, controller, timeoutMs)
+    const controller = controllers[index];
+    const disposeTimeout = createTimeout(ctx, controller, timeoutMs);
 
     try {
-      logger.debug(`${description} 开始请求`, candidate.label)
-      const raw = await candidate.run(controller.signal)
-      const parsed = parser(raw)
+      logger.debug(`${description} 开始请求`, candidate.label);
+      const raw = await candidate.run(controller.signal);
+      const parsed = parser(raw);
 
       if (parsed === null) {
-        throw new Error('返回结果不可用')
+        throw new Error("返回结果不可用");
       }
 
-      logger.debug(`${description} 命中`, candidate.label)
-      return parsed
+      logger.debug(`${description} 命中`, candidate.label);
+      return parsed;
     } catch (error) {
-      if (controller.signal.aborted && controller.signal.reason === REQUEST_TIMEOUT_REASON) {
-        throw new Error(`${candidate.label} 请求超时`)
+      if (
+        controller.signal.aborted &&
+        controller.signal.reason === REQUEST_TIMEOUT_REASON
+      ) {
+        throw new Error(`${candidate.label} 请求超时`);
       }
 
       if (controller.signal.aborted) {
-        throw new Error(`${candidate.label} 已取消`)
+        throw new Error(`${candidate.label} 已取消`);
       }
 
-      throw new Error(`${candidate.label} 请求失败：${getErrorMessage(error)}`)
+      throw new Error(`${candidate.label} 请求失败：${getErrorMessage(error)}`);
     } finally {
-      disposeTimeout()
+      disposeTimeout();
     }
-  })
+  });
 
   try {
-    return await Promise.any(tasks)
+    return await Promise.any(tasks);
   } catch (error) {
-    logger.error(`${description} 全部失败`, error)
-    throw error
+    logger.error(`${description} 全部失败`, error);
+    throw error;
   } finally {
     for (const controller of controllers) {
-      controller.abort()
+      controller.abort();
     }
   }
 }
 
 function parseSearchResponse(content: string) {
   try {
-    const parsed = JSON.parse(content) as NetEaseSearchResponse
+    const parsed = JSON.parse(content) as NetEaseSearchResponse;
 
-    if (!parsed || typeof parsed !== 'object') {
-      return null
+    if (!parsed || typeof parsed !== "object") {
+      return null;
     }
 
-    return parsed
+    return parsed;
   } catch {
-    return null
+    return null;
   }
 }
 
 function tryParseUrl(content: string) {
-  const trimmed = content.trim()
+  const trimmed = content.trim();
 
   if (!trimmed) {
-    return null
+    return null;
   }
 
   try {
-    const parsed = new URL(trimmed)
+    const parsed = new URL(trimmed);
 
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return trimmed
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return trimmed;
     }
   } catch {
     // 忽略，继续尝试解析 JSON。
   }
 
   try {
-    const parsed = JSON.parse(trimmed) as { url?: unknown }
+    const parsed = JSON.parse(trimmed) as { url?: unknown };
 
-    if (typeof parsed.url !== 'string') {
-      return null
+    if (typeof parsed.url !== "string") {
+      return null;
     }
 
-    const normalized = parsed.url.trim()
-    const url = new URL(normalized)
+    const normalized = parsed.url.trim();
+    const url = new URL(normalized);
 
-    if (url.protocol === 'http:' || url.protocol === 'https:') {
-      return normalized
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return normalized;
     }
   } catch {
-    return null
+    return null;
   }
 
-  return null
+  return null;
 }
 
 function resolveExtension(contentType: string | null) {
   if (!contentType) {
-    return '.mp3'
+    return ".mp3";
   }
 
-  if (contentType.includes('audio/mpeg')) return '.mp3'
-  if (contentType.includes('audio/mp4')) return '.m4a'
-  if (contentType.includes('audio/wav')) return '.wav'
-  if (contentType.includes('audio/flac')) return '.flac'
+  if (contentType.includes("audio/mpeg")) return ".mp3";
+  if (contentType.includes("audio/mp4")) return ".m4a";
+  if (contentType.includes("audio/wav")) return ".wav";
+  if (contentType.includes("audio/flac")) return ".flac";
 
-  return '.mp3'
+  return ".mp3";
 }
 
-async function fetchArrayBuffer(ctx: Context, targetUrl: string, timeoutMs: number) {
-  const controller = new AbortController()
-  const disposeTimeout = createTimeout(ctx, controller, timeoutMs)
+async function fetchArrayBuffer(
+  ctx: Context,
+  targetUrl: string,
+  timeoutMs: number
+) {
+  const controller = new AbortController();
+  const disposeTimeout = createTimeout(ctx, controller, timeoutMs);
 
   try {
     const response = await fetch(targetUrl, {
-      method: 'GET',
+      method: "GET",
       signal: controller.signal,
-    })
+    });
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`)
+      throw new Error(`HTTP ${response.status}`);
     }
 
     return {
       buffer: Buffer.from(await response.arrayBuffer()),
-      contentType: response.headers.get('content-type'),
-    }
+      contentType: response.headers.get("content-type"),
+    };
   } finally {
-    disposeTimeout()
-    controller.abort()
+    disposeTimeout();
+    controller.abort();
   }
 }
 
@@ -283,59 +317,111 @@ export async function searchNetEase(
   keyword: string,
   limit: number,
   offset: number,
-  logger: PluginLogger,
+  logger: PluginLogger
 ) {
-  const searchApiUrl = `http://music.163.com/api/search/get/web?csrf_token=hlpretag=&hlposttag=&s=${encodeURIComponent(keyword)}&type=1&offset=${offset}&total=true&limit=${limit}`
+  const searchApiUrl = `http://music.163.com/api/search/get/web?csrf_token=hlpretag=&hlposttag=&s=${encodeURIComponent(
+    keyword
+  )}&type=1&offset=${offset}&total=true&limit=${limit}`;
   const response = await raceRequests(
     ctx,
-    buildSearchCandidates([searchApiUrl], config.searchRequestMode, SEARCH_TIMEOUT_MS),
+    buildSearchCandidates(
+      [searchApiUrl],
+      config.searchRequestMode,
+      SEARCH_TIMEOUT_MS
+    ),
     SEARCH_TIMEOUT_MS,
     parseSearchResponse,
-    '网易云搜索',
-    logger,
-  )
+    "网易云搜索",
+    logger
+  );
 
-  const songs = response.result?.songs ?? []
+  const songs = response.result?.songs ?? [];
 
   return songs.map<SongData>((song) => ({
     id: song.id,
     name: song.name,
-    artists: song.artists.map((artist) => artist.name).join('/'),
+    artists: song.artists.map((artist) => artist.name).join("/"),
     albumName: song.album.name,
     duration: song.duration,
-  }))
+  }));
 }
 
 export async function resolveSongSource(
   ctx: Context,
   config: RuntimeConfig,
   songId: number,
-  logger: PluginLogger,
+  logger: PluginLogger
 ) {
-  const targetUrls = config.type === 'apis'
-    ? PRESET_METING_APIS.map((api) => `${api}?server=netease&type=url&id=${songId}`)
-    : [`${config.text}?server=netease&type=url&id=${songId}`]
+  const targetUrls =
+    config.type === "apis"
+      ? PRESET_METING_APIS.map(
+          (api) => `${api}?server=netease&type=url&id=${songId}`
+        )
+      : [`${config.text}?server=netease&type=url&id=${songId}`];
 
   return await raceRequests(
     ctx,
     buildDirectCandidates(targetUrls),
     SOURCE_TIMEOUT_MS,
     tryParseUrl,
-    '歌曲直链获取',
-    logger,
-  )
+    "歌曲直链获取",
+    logger
+  );
+}
+
+export async function resolvePodcastSource(
+  ctx: Context,
+  config: RuntimeConfig,
+  podcastUrl: string,
+  logger: PluginLogger
+) {
+  const url = new URL(podcastUrl);
+  const programId = url.searchParams.get("id");
+  if (!programId || !/^\d+$/.test(programId)) {
+    throw new Error("网易云播客链接缺少有效的节目 ID");
+  }
+
+  const controller = new AbortController();
+  const disposeTimeout = createTimeout(ctx, controller, SOURCE_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `https://music.163.com/api/dj/program/detail?id=${programId}`,
+      {
+        signal: controller.signal,
+        headers: {
+          "User-Agent": "Mozilla/5.0",
+          Referer: "https://music.163.com/",
+        },
+      }
+    );
+    if (!response.ok) throw new Error(`节目详情 HTTP ${response.status}`);
+    const data = (await response.json()) as {
+      program?: { mainSong?: { id?: number }; duration?: number };
+    };
+    const songId = data.program?.mainSong?.id;
+    if (!songId) throw new Error("节目详情中没有找到音频 ID");
+    logger.debug("网易云播客节目已解析", { programId, songId });
+
+    const source = await resolveSongSource(ctx, config, songId, logger);
+    return { source, duration: data.program?.duration ?? 0, songId };
+  } finally {
+    disposeTimeout();
+    controller.abort();
+  }
 }
 
 export async function fetchSongBuffer(ctx: Context, targetUrl: string) {
-  const result = await fetchArrayBuffer(ctx, targetUrl, DOWNLOAD_TIMEOUT_MS)
-  return result.buffer
+  const result = await fetchArrayBuffer(ctx, targetUrl, DOWNLOAD_TIMEOUT_MS);
+  return result.buffer;
 }
 
 export async function downloadSongFile(ctx: Context, targetUrl: string) {
-  const result = await fetchArrayBuffer(ctx, targetUrl, DOWNLOAD_TIMEOUT_MS)
-  const filename = `${crypto.randomBytes(8).toString('hex')}${resolveExtension(result.contentType)}`
-  const filePath = path.join(os.tmpdir(), filename)
+  const result = await fetchArrayBuffer(ctx, targetUrl, DOWNLOAD_TIMEOUT_MS);
+  const filename = `${crypto.randomBytes(8).toString("hex")}${resolveExtension(
+    result.contentType
+  )}`;
+  const filePath = path.join(os.tmpdir(), filename);
 
-  await fs.writeFile(filePath, result.buffer)
-  return filePath
+  await fs.writeFile(filePath, result.buffer);
+  return filePath;
 }


### PR DESCRIPTION
 ## Changes

     - Add direct support for NetEase Cloud Music podcast links.
     - Resolve podcast program details and audio source automatically.
     - Prevent podcast URLs from entering the normal song search flow.
     - Fix NetEase Meting requests by specifying `server=netease`.
     - Update README with podcast usage instructions.

     ## Verification

     - esbuild bundle check passed
     - Node.js syntax check passed
     - git diff --check passed